### PR TITLE
Support for filtering middle-wildcard domains

### DIFF
--- a/traversal.go
+++ b/traversal.go
@@ -36,3 +36,17 @@ func RegisteredToFQDN(registered, fqdn string, callback func(domain string) bool
 		}
 	}
 }
+
+// SplitRegisteredToFQDN executes the provided callback routine for domain names, splitting
+// the registered domain into a prefix and suffix part and omitting the part in between.
+// The process stops if the callback routine returns true, indicating completion.
+func SplitRegisteredToFQDN(registered, fqdn string, callback func(prefix, suffix string) bool) {
+	base := len(strings.Split(registered, "."))
+	labels := strings.Split(fqdn, ".")
+
+	for i := 1; i <= len(labels)-base-1; i++ {
+		if callback(strings.Join(labels[:i], "."), strings.Join(labels[i+1:], ".")) {
+			break
+		}
+	}
+}

--- a/traversal_test.go
+++ b/traversal_test.go
@@ -151,20 +151,7 @@ func TestSplitRegisteredToFQDN(t *testing.T) {
 			name:       "Only TLD+1",
 			fqdn:       "ezproxy.utica.edu",
 			registered: "utica.edu",
-			expected: []Result{
-				{
-					"www",
-					"com.ezproxy.utica.edu",
-				},
-				{
-					"www.accessphysiotherapy",
-					"ezproxy.utica.edu",
-				},
-				{
-					"www.accessphysiotherapy.com",
-					"utica.edu",
-				},
-			},
+			expected:   []Result{},
 			callback: func(prefix, suffix string) bool {
 				got = append(got, Result{
 					prefix,

--- a/wildcards.go
+++ b/wildcards.go
@@ -42,7 +42,12 @@ type wildcard struct {
 }
 
 // UnlikelyName takes a subdomain name and returns an unlikely DNS name within that subdomain.
-func UnlikelyName(prefix, suffix string) string {
+func UnlikelyName(sub string) string {
+	return UnlikelyNameFromSplit("", sub)
+}
+
+// UnlikelyNameFromSplit takes a subdomain prefix and suffix and returns an unlikely DNS name in the middle of those.
+func UnlikelyNameFromSplit(prefix, suffix string) string {
 	ldh := []rune(LDHChars)
 	ldhLen := len(ldh)
 
@@ -216,7 +221,7 @@ func (r *Resolvers) wildcardTest(ctx context.Context, prefix, suffix string) (bo
 	for i := 0; i < numOfWildcardTests; i++ {
 		var name string
 		for {
-			name = UnlikelyName(prefix, suffix)
+			name = UnlikelyNameFromSplit(prefix, suffix)
 			if name != "" {
 				break
 			}

--- a/wildcards_test.go
+++ b/wildcards_test.go
@@ -58,6 +58,16 @@ func TestWildcardDetected(t *testing.T) {
 			input: "ns.wildcard.domain.com",
 			want:  false,
 		},
+		{
+			label: "invalid name within a middle-wildcard",
+			input: "wildcard.jeff_foley.domain.com",
+			want:  true,
+		},
+		{
+			label: "valid name within a middle-wildcard",
+			input: "wildcard.app.domain.com",
+			want:  false,
+		},
 	}
 
 	for _, c := range cases {
@@ -83,6 +93,10 @@ func wildcardHandler(w dns.ResponseWriter, req *dns.Msg) {
 		addr = "192.168.1.2"
 	} else if strings.HasSuffix(name, ".wildcard.domain.com.") {
 		addr = "192.168.1.64"
+	} else if strings.HasPrefix(name, "wildcard.") && strings.HasSuffix(name, ".domain.com") {
+		addr = "192.168.1.65"
+	} else if name == "wildcard.app.domain.com" {
+		addr = "192.168.1.66"
 	}
 
 	if addr == "" {

--- a/wildcards_test.go
+++ b/wildcards_test.go
@@ -13,6 +13,17 @@ import (
 	"github.com/miekg/dns"
 )
 
+func TestUnlikelyName(t *testing.T) {
+	name := UnlikelyName("proxy", "example.com")
+	if !strings.HasPrefix(name, "proxy.") {
+		t.Fatalf("Unlikely name `%s` does not have `%s` prefix", name, "proxy.")
+	}
+	if !strings.HasSuffix(name, ".example.com") {
+		t.Fatalf("Unlikely name `%s` does not have `%s` suffix", name, ".example.com")
+	}
+	t.Log(name)
+}
+
 func TestSetDetectionResolver(t *testing.T) {
 	r := NewResolvers()
 	defer r.Stop()
@@ -93,9 +104,9 @@ func wildcardHandler(w dns.ResponseWriter, req *dns.Msg) {
 		addr = "192.168.1.2"
 	} else if strings.HasSuffix(name, ".wildcard.domain.com.") {
 		addr = "192.168.1.64"
-	} else if strings.HasPrefix(name, "wildcard.") && strings.HasSuffix(name, ".domain.com") {
+	} else if name == "wildcard.app.domain.com." {
 		addr = "192.168.1.65"
-	} else if name == "wildcard.app.domain.com" {
+	} else if strings.HasPrefix(name, "wildcard.") && strings.HasSuffix(name, ".domain.com.") {
 		addr = "192.168.1.66"
 	}
 

--- a/wildcards_test.go
+++ b/wildcards_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/miekg/dns"
 )
 
-func TestUnlikelyName(t *testing.T) {
-	name := UnlikelyName("proxy", "example.com")
+func TestUnlikelyNameFromSplit(t *testing.T) {
+	name := UnlikelyNameFromSplit("proxy", "example.com")
 	if !strings.HasPrefix(name, "proxy.") {
 		t.Fatalf("Unlikely name `%s` does not have `%s` prefix", name, "proxy.")
 	}


### PR DESCRIPTION
This PR adds support for detecting wildcards that are in the middle of a domain name, as opposed to those at the start of a domain name.

This will increase the amount of DNS queries significantly for multi-level domains.

Kind regards from @hadriansecurity :wink: 